### PR TITLE
feat: add `create_certificate_with_sid`

### DIFF
--- a/examples/sign_binary.rs
+++ b/examples/sign_binary.rs
@@ -341,7 +341,6 @@ fn sign_file<S: SessionLike>(
     let pe = PE::parse(&contents).expect("Failed to parse the PE binary");
 
     let certificate;
-    let issuer;
     {
         let parent = parents.last().unwrap();
         // Create a unique certificate for this particular instance,
@@ -364,18 +363,12 @@ fn sign_file<S: SessionLike>(
         certificate = builder
             .build::<ecdsa::der::Signature<p256::NistP256>>()
             .expect("Failed to assemble the certificate");
-        issuer = cms::signed_data::SignerIdentifier::IssuerAndSerialNumber(
-            cms::cert::IssuerAndSerialNumber {
-                issuer: parent.tbs_certificate.issuer.clone(),
-                serial_number: parent.tbs_certificate.serial_number.clone(),
-            },
-        );
     }
-    parents.push(certificate);
+    parents.push(certificate.clone());
     let pe_certificate = create_certificate::<Sha256, _, ecdsa::der::Signature<_>>(
         &pe,
         parents,
-        issuer,
+        certificate,
         parent_signer,
     )
     .expect("Failed to produce an PE attribute certificate");

--- a/tests/test_snakeoil_sign.rs
+++ b/tests/test_snakeoil_sign.rs
@@ -7,7 +7,7 @@ use cms::cert::IssuerAndSerialNumber;
 use digest::Digest;
 use goblin::pe::{writer::PEWriter, PE};
 use goblin_signing::authenticode::Authenticode;
-use goblin_signing::sign::create_certificate;
+use goblin_signing::sign::create_certificate_with_sid;
 use goblin_signing::verify::{certificates_from_pe, verify_pe_signatures_no_trust};
 use p256::ecdsa::SigningKey;
 use sha2::Sha256;
@@ -56,7 +56,7 @@ fn test_create_attribute_certificate() {
     let signing_key = SigningKey::random(&mut OsRng);
     let sid = build_issuer("CN=test", 1).expect("Failed to build a trivial issuer");
     let certificate = build_certificate("CN=test", 1, &signing_key);
-    let _ = create_certificate::<Sha256, _, ecdsa::der::Signature<_>>(
+    let _ = create_certificate_with_sid::<Sha256, _, ecdsa::der::Signature<_>>(
         &pe,
         vec![certificate],
         sid,
@@ -89,7 +89,7 @@ fn test_attaching_attribute_certificate_to_pe() {
         "Pending PE digest: {:?}",
         pending_pe.authenticode_dyndigest(Box::new(sha2::Sha256::new()))
     );
-    let attr_cert = create_certificate::<Sha256, _, ecdsa::der::Signature<_>>(
+    let attr_cert = create_certificate_with_sid::<Sha256, _, ecdsa::der::Signature<_>>(
         &pending_pe,
         vec![certificate],
         sid,
@@ -143,7 +143,7 @@ fn test_multisig_pe() {
         .write_into()
         .expect("Failed to write an unsigned PE");
     let pending_pe = PE::parse(&pending_pe[..]).expect("Failed to parse the unsigned PE");
-    let attr_cert = create_certificate::<Sha256, _, ecdsa::der::Signature<_>>(
+    let attr_cert = create_certificate_with_sid::<Sha256, _, ecdsa::der::Signature<_>>(
         &pending_pe,
         vec![certificate],
         sid,


### PR DESCRIPTION
Usually, a SID is cumbersome to produce for a certificate, most of the time, we can reuse the leaf's certificate issuer information.

`create_certificate` now takes a leaf certificate to extract the issuer information from.