### PR TITLE
chore: move to `ifrit`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,9 @@ categories = ["cryptography", "parsing"]
 [dependencies]
 digest = { version = "0.10.6", features = [ "alloc" ] }
 # waiting for a release of goblin
-goblin = { git = "https://github.com/RaitoBezarius/goblin.git", branch = "goblin-signing" }
+goblin = { git = "https://github.com/RaitoBezarius/goblin.git", branch = "preps-for-ifrit-1" }
+# waiting for a release of ifrit
+ifrit = { git = "https://github.com/RaitoBezarius/ifrit.git" }
 cms = { version = "0.2.2", features = [ "builder" ] }
 der = { version = "0.7.7", default-features = false }
 x509-cert = { version = "0.2.3" }
@@ -27,16 +29,13 @@ cryptoki-rustcrypto = { git = "https://github.com/baloo/rust-cryptoki", branch =
 thiserror = "1.0.49"
 stderrlog = "0.5.4"
 x509-verify = { version = "0.4.2", features = [ "x509", "ecdsa" ] }
-scroll = "0.11.0"
+scroll = { version = "0.12.0", features = [ "derive" ] }
 uuid = { version = "1.5.0", features = [ "v4" ] }
 percent-encoding = "2.3.0"
 uriparse = "0.6.4"
 log = "0.4.20"
 pkcs11-uri = "0.1.3"
 p256 = "0.13.2"
-
-[patch.crates-io]
-scroll = { git = "https://github.com/RaitoBezarius/scroll.git", branch = "goblin-signing" }
 
 [[example]]
 name = "sign_binary"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,6 +37,9 @@ log = "0.4.20"
 pkcs11-uri = "0.1.3"
 p256 = "0.13.2"
 
+[patch."https://github.com/RaitoBezarius/goblin.git"]
+goblin = { path = "../../m4b/goblin" }
+
 [[example]]
 name = "sign_binary"
 
@@ -46,4 +49,6 @@ name = "verify_binary"
 [dev-dependencies]
 bitflags = "2.4.1"
 clap = { version = "4.4.8", features = [ "derive" ] }
+pretty_assertions = "1.4.0"
 rpassword = "7.3.1"
+stderrlog = "0.5.4"

--- a/examples/sign_binary.rs
+++ b/examples/sign_binary.rs
@@ -20,8 +20,9 @@ use cryptoki::{
 };
 use cryptoki_rustcrypto::{x509::CertPkcs11, SessionLike};
 use der::Encode;
-use goblin::pe::{writer::PEWriter, PE};
+use goblin::pe::PE;
 use goblin_signing::sign::create_certificate;
+use ifrit::writer::PEWriter;
 use pkcs11_uri::Pkcs11Uri;
 use rpassword::read_password;
 use sha2::Sha256;
@@ -381,7 +382,7 @@ fn sign_file<S: SessionLike>(
     .expect("Failed to produce an PE attribute certificate");
     let mut pe_writer = PEWriter::new(pe).expect("Failed to construct the PE writer");
     pe_writer
-        .attach_certificates(vec![pe_certificate])
+        .attach_certificates(vec![pe_certificate.attribute()])
         .expect("Failed to attach a new certificate to PE");
     println!("Signed!");
     std::fs::write(

--- a/examples/sign_binary.rs
+++ b/examples/sign_binary.rs
@@ -382,7 +382,9 @@ fn sign_file<S: SessionLike>(
     .expect("Failed to produce an PE attribute certificate");
     let mut pe_writer = PEWriter::new(pe).expect("Failed to construct the PE writer");
     pe_writer
-        .attach_certificates(vec![pe_certificate.attribute()])
+        .attach_certificates(vec![pe_certificate
+            .attribute()
+            .expect("Failed to produce a certificate")])
         .expect("Failed to attach a new certificate to PE");
     println!("Signed!");
     std::fs::write(

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -8,6 +8,8 @@ pub enum SignatureError {
     UnknownSignatureAlgorithmIdentifier(#[from] spki::Error),
     #[error("Failed to run the signer information through the signer")]
     SigningError(#[from] x509_cert::builder::Error),
+    #[error("Malformed PE at assembly time")]
+    MalformedPE(#[from] goblin::error::Error),
 }
 
 #[derive(Error, Debug)]

--- a/src/sign.rs
+++ b/src/sign.rs
@@ -43,12 +43,12 @@ impl CertificateBundle {
         }
     }
 
-    pub fn attribute(&self) -> AttributeCertificate {
-        AttributeCertificate::from_bytes(
+    pub fn attribute(&self) -> Result<AttributeCertificate, SignatureError> {
+        Ok(AttributeCertificate::from_bytes(
             &self.certificate_raw,
             self.attribute_revision,
             self.attribute_type,
-        )
+        )?)
     }
 }
 

--- a/src/sign.rs
+++ b/src/sign.rs
@@ -6,7 +6,12 @@ use cms::{
 };
 use der::Encode;
 use digest::Digest;
-use goblin::pe::{certificate_table::AttributeCertificate, PE};
+use goblin::pe::{
+    certificate_table::{
+        AttributeCertificate, AttributeCertificateRevision, AttributeCertificateType,
+    },
+    PE,
+};
 use signature::{Keypair, Signer};
 use x509_cert::{
     spki::{DynSignatureAlgorithmIdentifier, EncodePublicKey, SignatureBitStringEncoding},
@@ -16,6 +21,37 @@ use x509_cert::{
 use crate::errors::SignatureError;
 use crate::{authenticode::Authenticode, certificate::DigestInfo};
 
+/// Because [`AttributeCertificate`] is a purely borrowing a structure,
+/// we cannot return it naked, we need to own the raw certificate data somewhere.
+#[derive(Debug, Clone)]
+pub struct CertificateBundle {
+    certificate_raw: Vec<u8>,
+    attribute_revision: AttributeCertificateRevision,
+    attribute_type: AttributeCertificateType,
+}
+
+impl CertificateBundle {
+    pub fn new(
+        raw: Vec<u8>,
+        attribute_revision: AttributeCertificateRevision,
+        attribute_type: AttributeCertificateType,
+    ) -> Self {
+        Self {
+            certificate_raw: raw,
+            attribute_revision,
+            attribute_type,
+        }
+    }
+
+    pub fn attribute(&self) -> AttributeCertificate {
+        AttributeCertificate::from_bytes(
+            &self.certificate_raw,
+            self.attribute_revision,
+            self.attribute_type,
+        )
+    }
+}
+
 /// Produces a certificate for the given PE
 /// with the given signer identifier and signer.
 pub fn create_certificate<'pe, D: Digest, S, Signature>(
@@ -23,7 +59,7 @@ pub fn create_certificate<'pe, D: Digest, S, Signature>(
     certificates: Vec<Certificate>,
     sid: SignerIdentifier,
     signer: &S,
-) -> Result<AttributeCertificate<'pe>, SignatureError>
+) -> Result<CertificateBundle, SignatureError>
 where
     D: const_oid::AssociatedOid,
     S: Keypair + DynSignatureAlgorithmIdentifier,
@@ -66,8 +102,8 @@ where
     let mut certificate_contents = Vec::new();
     signed_data.encode_to_vec(&mut certificate_contents)?;
 
-    Ok(AttributeCertificate::from_bytes(
-        certificate_contents.into(),
+    Ok(CertificateBundle::new(
+        certificate_contents,
         goblin::pe::certificate_table::AttributeCertificateRevision::Revision2_0,
         goblin::pe::certificate_table::AttributeCertificateType::PkcsSignedData,
     ))

--- a/src/verify.rs
+++ b/src/verify.rs
@@ -24,12 +24,12 @@ pub struct VerificationOptions {
 pub fn certificates_from_pe(pe: &PE) -> Vec<(SignedData, DigestInfo)> {
     pe.certificates
         .iter()
-        .filter_map(|(_, cert)| {
-            match (cert.as_signed_data(), cert.as_spc_indirect_data_content()) {
+        .filter_map(
+            |cert| match (cert.as_signed_data(), cert.as_spc_indirect_data_content()) {
                 (Some(Ok(sdata)), Some(Ok(spc))) => Some((sdata, spc.message_digest)),
                 _ => None,
-            }
-        })
+            },
+        )
         .collect()
 }
 


### PR DESCRIPTION
To make things easier, I decided to move the PE writer into another subcrate called `ifrit` which will mature the PE writer and maybe merge it back in `faerie` in the future.

This tests things with the latest PR in Goblin: https://github.com/m4b/goblin/pull/389.

All tests are passing locally.